### PR TITLE
Fix innocuous CDK builder bug

### DIFF
--- a/codegen/src/main/scala/io/burkard/cdk/codegen/CdkBuilder.scala
+++ b/codegen/src/main/scala/io/burkard/cdk/codegen/CdkBuilder.scala
@@ -154,7 +154,7 @@ final case class CdkBuilder private[codegen](
            |    ${typeAnnotatedParameters.mkString(",\n    ")}
            |  )(implicit stackCtx: software.amazon.awscdk.Stack): $instanceCanonicalName""".stripMargin
       } else {
-        s"def apply(id: String)(implicit stackCtx: software.amazon.awscdk.Stack): $instanceCanonicalName"
+        s"def apply(internalResourceId: String)(implicit stackCtx: software.amazon.awscdk.Stack): $instanceCanonicalName"
       }
 
     // Add in create params first (required) and potentially fields as params (optional).


### PR DESCRIPTION
Never properly cleaned up generating code for zero-parameter builders that take an internal resource ID & stack context. Luckily did not cause any issues with previously published versions since there are no builders provided by the CDK that meet this pattern.