### PR TITLE
Weekly scala-steward PRs

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+pullRequests.frequency = "7 days"


### PR DESCRIPTION
AWS keeps spamming minor version releases, would rather only update dependencies weekly.