### PR TITLE
Default value of Java `Boolean` is `null`

### DIFF
--- a/project/FieldMethod.scala
+++ b/project/FieldMethod.scala
@@ -28,9 +28,7 @@ final case class FieldMethod private(
   lazy val requiresBooleanBoxing: Boolean = typeName.contains("java.lang.Boolean")
 
   lazy val defaultValue: String =
-    if (isOptional && typeName == "java.lang.Boolean") {
-      ".getOrElse(java.lang.Boolean.FALSE)"
-    } else if (isOptional) {
+    if (isOptional) {
       ".orNull"
     } else {
       ""


### PR DESCRIPTION
This was a mistake on my end 😅, the uninitialized (default) value of Java's `Boolean` is null. I mistakenly used the default value of the primitive `boolean`, which is `false`.

For example, slightly modified code (non-local code source) from https://github.com/NickBurkard/aws-cdk-scala/issues/51 which previously had issues on running `cdk synth` now produces a valid output.

```scala
import io.burkard.cdk._
import io.burkard.cdk.services.lambda._
import io.burkard.cdk.services.s3.Bucket
import software.amazon.awscdk.services.lambda.S3Code

object ExampleApp extends CdkApp {
  CdkStack(id = Some("ScalaStack")) { implicit stackCtx =>
    val bucket = Bucket(internalResourceId = "foo")

    Function(
      internalResourceId = "ScalaHandler",
      code = new S3Code(bucket, "bar"),
      handler = "lambda.handler",
      runtime = Runtime("nodejs14.x", RuntimeFamily.Nodejs)
    )
  }
}
```

```yaml
Resources:
  foo6445C170:
    Type: AWS::S3::Bucket
    UpdateReplacePolicy: Retain
    DeletionPolicy: Retain
    Metadata:
      aws:cdk:path: ScalaStack/foo/Resource
  ScalaHandlerServiceRole17FD8537:
    Type: AWS::IAM::Role
    Properties:
      AssumeRolePolicyDocument:
        Statement:
          - Action: sts:AssumeRole
            Effect: Allow
            Principal:
              Service: lambda.amazonaws.com
        Version: "2012-10-17"
      ManagedPolicyArns:
        - Fn::Join:
            - ""
            - - "arn:"
              - Ref: AWS::Partition
              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
    Metadata:
      aws:cdk:path: ScalaStack/ScalaHandler/ServiceRole/Resource
  ScalaHandler5C2B6FF8:
    Type: AWS::Lambda::Function
    Properties:
      Code:
        S3Bucket:
          Ref: foo6445C170
        S3Key: bar
      Role:
        Fn::GetAtt:
          - ScalaHandlerServiceRole17FD8537
          - Arn
      Handler: lambda.handler
      Runtime: nodejs14.x
    DependsOn:
      - ScalaHandlerServiceRole17FD8537
    Metadata:
      aws:cdk:path: ScalaStack/ScalaHandler/Resource
  CDKMetadata:
    Type: AWS::CDK::Metadata
    Properties:
      Analytics: v2:deflate64:H4sIAAAAAAAA/zWKvQ7CIBRGn6U7XIsd3G3i4Ng+gLkFTK78JQV0ILy7UuJ0Ts73neEC44CfyKUy3NIGZU0oDfulR4kTlGuWRic2P323yiy6TSGUW/YyUfBt+3tlhA
7KEqxuubHWw3QMeZdHnYNX1N93fONJCBhBTMMrEvE9+0ROw9L5BWfOxL6hAAAA
    Metadata:
      aws:cdk:path: ScalaStack/CDKMetadata/Default
    Condition: CDKMetadataAvailable
```